### PR TITLE
Replace ~ with system's HOME variable

### DIFF
--- a/src/org/kaivos/röda/IOUtils.java
+++ b/src/org/kaivos/röda/IOUtils.java
@@ -17,8 +17,9 @@ public final class IOUtils {
 	public static File getMaybeRelativeFile(File pwd, String name) {
 		if (name.startsWith("/")) { // tee tästä yhteensopiva outojen käyttöjärjestelmien kanssa
 			return new File(name);
-		}
-		else {
+		} else if (name.startsWith("~")) {
+			return new File(System.getenv("HOME"), name.replaceAll("~/?", ""));
+		}else {
 			return new File(pwd, name);
 		}
 	}


### PR DESCRIPTION
Normally when a command like `cd "~/path/to/dir"` is run, you get an error because the path is not recognised. This is because Java does not recognise `~` as the system's HOME variable. This commit fixes that by replacing the `~` with `System.getenv("HOME")`.